### PR TITLE
Replace empty spaces in links fixing markdown links not being generated

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -106,7 +106,7 @@ string? HtmlEscape(string? str)
     => str?.Replace("<", "&lt;").Replace(">", "&gt;");
 
 string? FileEscape(string? str)
-    => str?.Replace("<", "`").Replace(">", "`");
+    => str?.Replace("<", "`").Replace(">", "`").Replace(" ", "%20");
 
 string SourceLink(Item item)
     => item.Source?.Remote == null


### PR DESCRIPTION
DocFXMarkdownGen currently has the problem: Filenames with a space in between causes the links to be shown as such.

By replacing " " with %20 the filenames still can contain a space and the links are working now