### PR TITLE
Fix namespace links

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -176,7 +176,20 @@ string Link(string uid, bool linkFromGroupedType, bool nameOnly = false, bool li
         return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Namespace}/{reference.Name}{extension}")})";
     }
     else if (reference.Type is "Namespace")
+    {
+        if (config.RewriteInterlinks)
+        {
+            if (linkFromIndex)
+            {
+                return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Name}/{reference.Name}{extension}")})";
+            }
+            else
+            {
+                return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Name}")})";
+            }
+        }
         return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Name}/{reference.Name}{extension}")})";
+    }
     else
     {
         var parent = items.FirstOrDefault(i => i.Uid == reference.Parent);
@@ -612,6 +625,7 @@ class Config
     public string BrNewline { get; set; } = "\n\n";
     public bool ForceNewline { get; set; } = false;
     public string ForcedNewline { get; set; } = "  \n";
+    public bool RewriteInterlinks { get; set; } = false;
 }
 
 public class ConfigTypesGrouping

--- a/Program.cs
+++ b/Program.cs
@@ -106,7 +106,7 @@ string? HtmlEscape(string? str)
     => str?.Replace("<", "&lt;").Replace(">", "&gt;");
 
 string? FileEscape(string? str)
-    => str?.Replace("<", "`").Replace(">", "`");
+    => str?.Replace("<", "`").Replace(">", "`").Replace(" ", "%20");
 
 string SourceLink(Item item)
     => item.Source?.Remote == null

--- a/Program.cs
+++ b/Program.cs
@@ -176,20 +176,7 @@ string Link(string uid, bool linkFromGroupedType, bool nameOnly = false, bool li
         return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Namespace}/{reference.Name}{extension}")})";
     }
     else if (reference.Type is "Namespace")
-    {
-        if (config.RewriteInterlinks)
-        {
-            if (linkFromIndex)
-            {
-                return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Name}/{reference.Name}{extension}")})";
-            }
-            else
-            {
-                return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Name}")})";
-            }
-        }
         return $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Name}/{reference.Name}{extension}")})";
-    }
     else
     {
         var parent = items.FirstOrDefault(i => i.Uid == reference.Parent);
@@ -625,7 +612,6 @@ class Config
     public string BrNewline { get; set; } = "\n\n";
     public bool ForceNewline { get; set; } = false;
     public string ForcedNewline { get; set; } = "  \n";
-    public bool RewriteInterlinks { get; set; } = false;
 }
 
 public class ConfigTypesGrouping


### PR DESCRIPTION
Added the option to generate links to other docs without broken links warning from Docusaurus

With the new config setting RewriteInterlinks links are generated like "../log" instead of "../log/log" in case Docusaurus uses a file with the same name as the folder as index

See #11 