### PR TITLE
Add support for code blocks in other languages

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -23,7 +23,7 @@ WriteLine($"DocFxMarkdownGen v{versionString} running...");
 var xrefRegex = new Regex("<xref href=\"(.+?)\" data-throw-if-not-resolved=\"false\"></xref>", RegexOptions.Compiled);
 var langwordXrefRegex =
     new Regex("<xref uid=\"langword_csharp_.+?\" name=\"(.+?)\" href=\"\"></xref>", RegexOptions.Compiled);
-var codeBlockRegex = new Regex("<pre><code class=\"lang-csharp\">((.|\n)+?)</code></pre>", RegexOptions.Compiled);
+var codeBlockRegex = new Regex("<pre><code class=\"lang-([a-zA-Z0-9]+)\">((.|\n)+?)</code></pre>", RegexOptions.Compiled);
 var codeRegex = new Regex("<code>(.+?)</code>", RegexOptions.Compiled);
 var linkRegex = new Regex("<a href=\"(.+?)\">(.+?)</a>", RegexOptions.Compiled);
 var brRegex = new Regex("<br */?>", RegexOptions.Compiled);
@@ -210,7 +210,7 @@ string? GetSummary(string? summary, bool linkFromGroupedType)
         return Link(uid, linkFromGroupedType);
     });
     summary = langwordXrefRegex.Replace(summary, match => $"`{match.Groups[1].Value}`");
-    summary = codeBlockRegex.Replace(summary, match => $"```csharp\n{match.Groups[1].Value.Trim()}\n```");
+    summary = codeBlockRegex.Replace(summary, match => $"```{match.Groups[1].Value.Trim()}\n{match.Groups[2].Value.Trim()}\n```");
     summary = codeRegex.Replace(summary, match => $"`{match.Groups[1].Value}`");
     summary = linkRegex.Replace(summary, match => $"[{match.Groups[2].Value}]({match.Groups[1].Value})");
     summary = brRegex.Replace(summary, _ => config.BrNewline);


### PR DESCRIPTION
It has been some time since this repository has been active, so I apologize if this PR is unwanted, but the tool is still highly useful for myself.

The `<code>` tag in XML comments supports a `language` attribute to specify the language of the code in the block. DocFx's XML parser will pick this up and use it to produce the correct HTML markup.

Ex:
```
/// <code language="html"><![CDATA[
/// <span style="color: #F8F8F2;">Hello, world!</span>
/// ]]></code>
```

Produces:
```xml
<pre><code class="lang-html">&lt;span style="color: #F8F8F2;"&gt;Hello, world! &lt;/span&gt;</code></pre>
```

This PR corrects the behavior of DocFxMarkdownGen to match code blocks and not assume csharp for the lang.

Currently, DocFX doesn't properly handle replacing HTML entities with their raw character counterparts in code blocks (at least not in the metadata step) and Docusaurus will not fix this automatically inside code blocks. I think that it would be nice for dfmg to provide an option to replace HTML entities in codeblocks with their literal representations, but I think that deserves its own PR.