### PR TITLE
fix: newline after return with description

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -220,11 +220,11 @@ string? GetSummary(string? summary, bool linkFromGroupedType)
         summary = summary.Replace("\n", config.ForcedNewline);
 
     summary = HtmlEscape(summary);
-    
+
     if (config.UnescapeCodeBlocks)
         summary = markdownCodeBlockRegex.Replace(summary!,
             match => $"```{match.Groups[1].Value.Trim()}\n{WebUtility.HtmlDecode(match.Groups[2].Value.Trim())}\n```");
-    
+
     return summary;
 }
 
@@ -355,7 +355,7 @@ await Parallel.ForEachAsync(items, async (item, _) =>
                     if (string.IsNullOrWhiteSpace(method.Syntax.Return?.Description))
                         str.AppendLine();
                     else
-                        str.Append(": " + GetSummary(method.Syntax.Return.Description, isGroupedType));
+                        str.AppendLine(": " + GetSummary(method.Syntax.Return.Description, isGroupedType));
                 }
 
                 if (method.Syntax.Parameters is { Length: > 0 })


### PR DESCRIPTION
When a return value with description was used, no newline would be emitted. This would cause the headers for successive functions to be on the same line, which resulted in it not being recognised by the Markdown parser:
```markdown
##### Returns

`System.Boolean`: If Windows 11 has been detected.### OpenLink(string)
```

This fixes the issue by adding the missing `Line`:
```markdown
##### Returns

`System.Boolean`: If Windows 11 has been detected.
### OpenLink(string)
```