### PR TITLE
fix: ignore asterisks in links to items with names

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -198,7 +198,7 @@ string Link(string uid, bool linkFromGroupedType, bool nameOnly = false, bool li
         if (parent == null)
             return $"`{uid.Replace('{', '<').Replace('}', '>')}`";
         return
-            $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Namespace}{(NamespaceHasTypeGrouping(parent.Namespace) ? $"/{GetTypePathPart(parent.Type)}" : "")}/{parent.Name}{extension}")}#{reference.Name.ToLower().Replace("(", "").Replace(")", "").Replace("?", "")})";
+            $"[{HtmlEscape(name)}]({FileEscape($"{dots}{reference.Namespace}{(NamespaceHasTypeGrouping(parent.Namespace) ? $"/{GetTypePathPart(parent.Type)}" : "")}/{parent.Name}{extension}")}#{reference.Name.ToLower().Replace("(", "").Replace(")", "").Replace("?", "").Replace("*", "")})";
     }
 }
 


### PR DESCRIPTION
Links to a function with a pointer in the arguments were being emitted with the asterisk: `[ImGuiNET.ImGuiNative.igMemFree(void*)](../../ImGuiNET/Classes/ImGuiNative#igmemfreevoid*)`, but the header itself does not have the asterisk.

This fixes that by removing the asterisk from the link. This fix isn't ideal as it could go out of sync again, but I wanted to keep it simple. I'd suggest adding some kind of common slugification function with behaviour you can predict.