### PR TITLE
fix: always use .md extension in links for Docusaurus compatibility

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -170,7 +170,7 @@ string Link(string uid, bool linkFromGroupedType, bool nameOnly = false, bool li
     var name = nameOnly ? reference.Name : reference.FullName;
     var filename = config.UseUidFilename ? reference.Uid : reference.Name;
     var dots = linkFromIndex ? "./" : linkFromGroupedType ? "../../" : "../";
-    var extension = linkFromIndex ? ".md" : "";
+    var extension = ".md";
     if (reference.Type is "Class" or "Interface" or "Enum" or "Struct" or "Delegate")
     {
         if (NamespaceHasTypeGrouping(reference.Namespace))


### PR DESCRIPTION
Without .md extensions, Docusaurus passes links through as raw URL paths. When browsers resolve these relative URLs against pages served with trailing slashes, the relative path goes one level too few, producing duplicated namespace segments in the resolved URL.

Always using .md extensions tells Docusaurus to resolve links as file references at build time, which is immune to trailing slash behavior.

This fix was made to address https://github.com/goatcorp/dalamud-docs/issues/51.